### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "node index.js"

--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ I tried to make a proxy. This is my attempt at this. I've spent at least 6 hours
 You can see my 2 different attempts to do this. First, I tried to do it by using a standard GET request on the server, but I used a shitty module and gave up on that. Then, I tried using a CORS bypasser, which doesn't actually work since I made it in the client. Whatever, it wouldn't work anyways.
 
 This will just be left here for anyone else who wants to pick up the pieces I've made, as I haven't seen anything like this ever, frankly. The most similar thing I found was Google Translate, which isn't even that good.
+
+[![Run on Repl.it](https://repl.it/badge/github/xWafl/proxy-test)](https://repl.it/github/xWafl/proxy-test)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).